### PR TITLE
fix: update Metadata construction to use `new`, fix type mismatch

### DIFF
--- a/balatro_tui/src/tui.rs
+++ b/balatro_tui/src/tui.rs
@@ -136,12 +136,9 @@ fn init_panic_hook() -> Result<()> {
         {
             eprintln!("{}", msg); // prints color-eyre stack trace to stderr
             use human_panic::{handle_dump, print_msg, Metadata};
-            let meta = Metadata {
-                version: env!("CARGO_PKG_VERSION").into(),
-                name: env!("CARGO_PKG_NAME").into(),
-                authors: env!("CARGO_PKG_AUTHORS").replace(':', ", ").into(),
-                homepage: env!("CARGO_PKG_HOMEPAGE").into(),
-            };
+            let meta = Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+                .authors(env!("CARGO_PKG_AUTHORS").replace(':', ", "))
+                .homepage(env!("CARGO_PKG_HOMEPAGE"));
 
             let file_path = handle_dump(&meta, panic_info);
             // prints human-panic message


### PR DESCRIPTION
- Use `Metadata::new` instead of struct literal (fields are private)
- Fix type conversion issues with Option<Cow<str>>
- Allows successful build via `cargo install balatro_tui`